### PR TITLE
Avoid file seek when saving extracted files

### DIFF
--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -7,6 +7,7 @@ import xml.etree.ElementTree as ET
 import zipfile
 
 from django.core.files import File
+from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.template import Context, Template
 from django.utils import timezone
@@ -277,7 +278,8 @@ class ScormXBlock(XBlock):
                             os.path.relpath(zipinfo.filename, root_path),
                         )
                         self.storage.save(
-                            dest_path, scorm_zipfile.open(zipinfo.filename),
+                            dest_path,
+                            ContentFile(scorm_zipfile.read(zipinfo.filename)),
                         )
 
     @property


### PR DESCRIPTION
We are facing the following error because files are uploaded to Google Storage

```
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 1037, in handle
    results = handler(request, suffix)
  File "/edx/app/edxapp/venvs/edxapp/src/openedxscorm/openedxscorm/scormxblock.py", line 223, in studio_submit
    self.extract_package(package_file)
  File "/edx/app/edxapp/venvs/edxapp/src/openedxscorm/openedxscorm/scormxblock.py", line 280, in extract_package
    dest_path, scorm_zipfile.open(zipinfo.filename),
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/files/storage.py", line 54, in save
    return self._save(name, content)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/storages/backends/gcloud.py", line 159, in _save
    file.blob.upload_from_file(content, size=content.size,
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/files/base.py", line 59, in _get_size
    self._size = self._get_size_from_underlying_file()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/files/base.py", line 49, in _get_size_from_underlying_file
    pos = self.file.tell()
UnsupportedOperation: seek
```

This PR is to fix it by avoiding partial reads that need `seek` operation