### PR TITLE
add retrieving learner-related information for SCORM 1.2/2004

### DIFF
--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -43,6 +43,7 @@ logger = logging.getLogger(__name__)
 
 
 @XBlock.wants("settings")
+@XBlock.wants("user")
 class ScormXBlock(XBlock, CompletableXBlockMixin):
     """
     When a user uploads a Scorm package, the zip file is stored in:
@@ -371,6 +372,12 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
             return {"value": self.success_status}
         if name in ["cmi.core.score.raw", "cmi.score.raw"]:
             return {"value": self.lesson_score * 100}
+        user_service = self.runtime.service(self, 'user')
+        xb_user = user_service.get_current_user()
+        if name in ['cmi.core.student_id','cmi.learner_id']:
+            return {'value': xb_user.opt_attrs.get('edx-platform.user_id')}
+        if name in ['cmi.core.student_name','cmi.learner_name']:
+            return {'value': xb_user.opt_attrs.get('edx-platform.username')}
         return {"value": self.scorm_data.get(name, "")}
 
     @XBlock.json_handler

--- a/openedxscorm/tests.py
+++ b/openedxscorm/tests.py
@@ -3,7 +3,7 @@ import json
 import unittest
 
 
-from ddt import ddt, data
+from ddt import ddt, data, unpack
 from freezegun import freeze_time
 import mock
 from xblock.field_data import DictFieldData
@@ -275,3 +275,49 @@ class ScormXBlockTests(unittest.TestCase):
         )
 
         self.assertEqual(response.json, {"value": block.scorm_data[value["name"]]})
+
+    @data(
+        ({'name': 'cmi.core.student_id'}, 'edx-platform.user_id', 23),
+        ({'name': 'cmi.core.student_name'}, 'edx-platform.username', 'supername')
+    )
+    @unpack
+    def test_scorm_12_get_student_data(self, request_data, key, value):
+        service_user_mock = mock.Mock()
+        current_user_mock = mock.Mock()
+        current_user_mock.opt_attrs = {
+            key : value
+        }
+        service_user_mock.configure_mock(**{'get_current_user.return_value': current_user_mock})
+
+        runtime = mock.Mock()
+        runtime.service.return_value = service_user_mock
+
+        block = self.make_one(runtime=runtime)
+
+        response = block.scorm_get_value(
+            mock.Mock(method="POST", body=json.dumps(request_data))
+        )
+        self.assertEqual(response.json, {'value': value})
+        
+    @data(
+        ({'name': 'cmi.learner_id'}, 'edx-platform.user_id', 23),
+        ({'name': 'cmi.learner_name'}, 'edx-platform.username', 'supername')
+    )
+    @unpack
+    def test_scorm_2004_get_student_data(self, request_data, key, value):
+        service_user_mock = mock.Mock()
+        current_user_mock = mock.Mock()
+        current_user_mock.opt_attrs = {
+            key : value
+        }
+        service_user_mock.configure_mock(**{'get_current_user.return_value': current_user_mock})
+
+        runtime = mock.Mock()
+        runtime.service.return_value = service_user_mock
+
+        block = self.make_one(runtime=runtime)
+
+        response = block.scorm_get_value(
+            mock.Mock(method="POST", body=json.dumps(request_data))
+        )
+        self.assertEqual(response.json, {'value': value})    


### PR DESCRIPTION
Hi to all

This pull request is backport of https://github.com/raccoongang/edx_xblock_scorm/commit/84fcdb66628835bab7eff5e58936bb4583a36f04 and https://github.com/raccoongang/edx_xblock_scorm/commit/977c0e9186d04e28f09f396370372ed56e48e13c

It append support get user-related info according to[ SCORM 1.2 and 2004](https://scorm.com/scorm-explained/technical-scorm/run-time/run-time-reference/?utm_source=google&utm_medium=natural_search) (cmi.core.student_id/name  and cmi.learner_id/name)

Pull request has a test. But (shame on me) i'm not familiar with python/Django/EdX .
