### PR TITLE
fix: Problem with weight displaying related to localization is fixed

### DIFF
--- a/openedxscorm/static/html/studio.html
+++ b/openedxscorm/static/html/studio.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n l10n %}
 
 <div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
     <ul class="list-input settings-list">
@@ -35,7 +35,7 @@
         <li class="field comp-setting-entry is-set">
             <div class="wrapper-comp-setting">
                 <label class="label setting-label" for="weight">{% trans field_weight.display_name %}</label>
-                <input class="input setting-input" name="weight" id="weight" value="{{ scorm_xblock.weight }}" type="number" />
+                <input class="input setting-input" name="weight" id="weight" value="{{ scorm_xblock.weight|unlocalize }}" type="number" />
             </div>
             <span class="tip setting-help">{% trans field_weight.help %}</span>
         </li>


### PR DESCRIPTION
There is a problem with scorm weight displaying in settings from studio. To reproduce it we need to open xblock settings menu, change the weight value from default to new arbitrary one and save changes. After opening this menu again the displayed weight value is empty. The reason is localization. For the tested locale the float weight value is represented with ',' instead of '.', but it is incorrect value for input tag's `value` attribute, so nothing is displayed. To fix it, `unlocalize` filter is applied to scorm_xblock.weight value.