### PR TITLE
remove unused import

### DIFF
--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -5,7 +5,6 @@ import logging
 import re
 import xml.etree.ElementTree as ET
 import zipfile
-import requests
 import mimetypes
 
 from django.core.files.base import ContentFile


### PR DESCRIPTION
`requests` is imported but never used. It has been replaced by `urllib.request.urlopen`