### PR TITLE
docs: Update README for recent Open edX versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Features
 * Optional display in pop-up window
 * Integrated grading, compatible with rescoring
 * Compatibility with `Django storages <https://django-storages.readthedocs.io/>`__, customizable storage backend
-* Works with Maple, the latest Open edX release (use v12 for Lilac, v11 for Koa, v10 for Juniper and v9 for Ironwood)
+* v16 works with Palm, the latest Open edX release (use v15 for Olive, v14 for Nutmeg, v13 for Maple, and v12 for Lilac)
 
 Installation
 ------------


### PR DESCRIPTION
Explain that the v16 version is meant for Palm, and enumerate the
version numbers corresponding to recent Open edX releases.

Fixes #35.
