### PR TITLE
fix: avoid initializing student search autocomplete if reports are not needed

### DIFF
--- a/openedxscorm/static/js/src/scormxblock.js
+++ b/openedxscorm/static/js/src/scormxblock.js
@@ -93,6 +93,9 @@ function ScormXBlock(runtime, element, settings) {
     // Student reports
     var reportElement = $(element).find(".scorm-reports .report");
     function initReports() {
+        if (reportElement.length === 0){
+            return;
+        }
         $(element).find("button.view-reports").on("click", function () {
             viewReports();
         });


### PR DESCRIPTION
This PR has changes to fix a js error which causes failure to load SCORM content in LMS when multiple SCORM blocks are added in single unit and unit is access by learner. In case of Staff users this error does not popup. Changes in this PR stop initializing student search autocomplete in case of learners since learners don't need to view reports. 

JS Error from browser's console
```
properties of undefined (reading 'nodeType')
    at acceptData (lms-main_vendor.211c5a13e466.js:2:16678)
    at Data.cache (lms-main_vendor.211c5a13e466.js:2:17059)
    at Data.set (lms-main_vendor.211c5a13e466.js:2:17350)
    at Data.access (lms-main_vendor.211c5a13e466.js:2:17795)
    at Function.data (lms-main_vendor.211c5a13e466.js:2:19140)
    at e.<computed>.<computed>._createWidget (lms-main_vendor.211c5a13e466.js:11:17721)
    at new e.<computed>.<computed> (lms-main_vendor.211c5a13e466.js:11:15518)
    at e.<computed>.<computed> [as autocomplete] (lms-main_vendor.211c5a13e466.js:11:15484)
    at initReports (block-v1:edX+bk-sandbox+1T2030+type@vertical+block@1a06fd73bd2744cea6a66880d90c1dfb?show_title=0&show_bookmark_button=0&recheck_access=1&view=student_view:1004:14)
    at HTMLDocument.<anonymous> (block-v1:edX+bk-sandbox+1T2030+type@vertical+block@1a06fd73bd2744cea6a66880d90c1dfb?show_title=0&show_bookmark_button=0&recheck_access=1&view=student_view:1148:9)
 ```