### PR TITLE
fix: escape the '%' in gettext

### DIFF
--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -129,7 +129,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
     icon_class = String(default="video", scope=Scope.settings)
     width = Integer(
         display_name=_("Display width (px)"),
-        help=_("Width of iframe (default: 100%)"),
+        help=_("Width of iframe (default: 100%%)"),
         scope=Scope.settings,
     )
     height = Integer(


### PR DESCRIPTION
 Since '%' is a special character in gettext, to use in default
 message it has be to escaped, otherwise gettext would get the
 default strings in the templates.