### PR TITLE
Replace deprecated pkg_resources package with importlib_resources

### DIFF
--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -183,7 +183,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
     @staticmethod
     def resource_string(path):
         """Handy helper for getting static resources from our kit."""
-        data = importlib_resources.files(__package__).joinpath(path).read_bytes()
+        data = importlib_resources.files(__name__).joinpath(path).read_bytes()
         return data.decode("utf8")
 
     def author_view(self, context=None):

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -15,7 +15,7 @@ from django.template import Context, Template
 from django.utils import timezone
 from django.utils.module_loading import import_string
 from webob import Response
-import pkg_resources
+import importlib_resources
 from six import string_types
 
 from web_fragments.fragment import Fragment
@@ -183,7 +183,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
     @staticmethod
     def resource_string(path):
         """Handy helper for getting static resources from our kit."""
-        data = pkg_resources.resource_string(__name__, path)
+        data = importlib_resources.files(__package__).joinpath(path).read_bytes()
         return data.decode("utf8")
 
     def author_view(self, context=None):


### PR DESCRIPTION
Removed `pkg_resources` for compatibility with newer python versions as discussed in this [issue](https://github.com/overhangio/tutor/issues/966).

Ensured that this xblock is working with python `3.12` & `3.8` as mentioned in this [issue](https://github.com/overhangio/openedx-scorm-xblock/issues/67).