### PR TITLE
Improve GetValue API 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,7 +144,7 @@ Development
 
 Run unit tests with::
 
-    $ NO_PREREQ_INSTALL=1 paver test_system -s lms -t openedxscorm
+    $ pytest /mnt/openedx-scorm-xblock/openedxscorm/tests.py
 
 Troubleshooting
 ---------------

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -181,10 +181,13 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
         return self.runtime.service(self, "user").get_current_user()
 
     def initialize_student_info(self):
-        self.scorm_data["cmi.core.student_id"] = self.get_current_user_attr("edx-platform.user_id")
-        self.scorm_data["cmi.learner_id"] = self.get_current_user_attr("edx-platform.user_id")
-        self.scorm_data["cmi.learner_name"] = self.get_current_user_attr("edx-platform.username")
-        self.scorm_data["cmi.core.student_name"] = self.get_current_user_attr("edx-platform.username")
+        user_id = self.get_current_user_attr("edx-platform.user_id")
+        username = self.get_current_user_attr("edx-platform.username")
+        
+        self.scorm_data["cmi.core.student_id"] = user_id
+        self.scorm_data["cmi.learner_id"] = user_id
+        self.scorm_data["cmi.learner_name"] = username
+        self.scorm_data["cmi.core.student_name"] = username
 
     @staticmethod
     def resource_string(path):

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -180,6 +180,12 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
     def get_current_user(self):
         return self.runtime.service(self, "user").get_current_user()
 
+    def initialize_student_info(self):
+        self.scorm_data["cmi.core.student_id"] = self.get_current_user_attr("edx-platform.user_id")
+        self.scorm_data["cmi.learner_id"] = self.get_current_user_attr("edx-platform.user_id")
+        self.scorm_data["cmi.learner_name"] = self.get_current_user_attr("edx-platform.username")
+        self.scorm_data["cmi.core.student_name"] = self.get_current_user_attr("edx-platform.username")
+
     @staticmethod
     def resource_string(path):
         """Handy helper for getting static resources from our kit."""
@@ -204,6 +210,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
             "popup_on_launch": self.popup_on_launch,
         }
         student_context.update(context or {})
+        self.initialize_student_info()
         template = self.render_template("static/html/scormxblock.html", student_context)
         frag = Fragment(template)
         frag.add_css(self.resource_string("static/css/scormxblock.css"))

--- a/openedxscorm/static/js/src/scormxblock.js
+++ b/openedxscorm/static/js/src/scormxblock.js
@@ -178,6 +178,7 @@ function ScormXBlock(runtime, element, settings) {
         "cmi.success_status",
         "cmi.core.score.raw",
         "cmi.score.raw",
+        "cmi.score.scaled",
         "cmi.mode"
     ];
     var getValueUrl = runtime.handlerUrl(element, 'scorm_get_value');

--- a/openedxscorm/tests.py
+++ b/openedxscorm/tests.py
@@ -3,7 +3,7 @@ import json
 import unittest
 
 
-from ddt import ddt, data, unpack
+from ddt import ddt, data
 from freezegun import freeze_time
 import mock
 from xblock.field_data import DictFieldData
@@ -255,68 +255,3 @@ class ScormXBlockTests(unittest.TestCase):
 
         self.assertEqual(response.json, {"value": 20})
 
-    @data(
-        {"name": "cmi.core.lesson_location"},
-        {"name": "cmi.location"},
-        {"name": "cmi.suspend_data"},
-    )
-    def test_get_other_scorm_values(self, value):
-        block = self.make_one(
-            scorm_data={
-                "cmi.core.lesson_location": 1,
-                "cmi.location": 2,
-                "cmi.suspend_data": [1, 2],
-            }
-        )
-
-        response = block.scorm_get_value(
-            mock.Mock(method="POST", body=json.dumps(value))
-        )
-
-        self.assertEqual(response.json, {"value": block.scorm_data[value["name"]]})
-
-    @data(
-        ({"name": "cmi.core.student_id"}, "edx-platform.user_id", 23),
-        ({"name": "cmi.core.student_name"}, "edx-platform.username", "supername"),
-    )
-    @unpack
-    def test_scorm_12_get_student_data(self, request_data, key, value):
-        service_user_mock = mock.Mock()
-        current_user_mock = mock.Mock()
-        current_user_mock.opt_attrs = {key: value}
-        service_user_mock.configure_mock(
-            **{"get_current_user.return_value": current_user_mock}
-        )
-
-        runtime = mock.Mock()
-        runtime.service.return_value = service_user_mock
-
-        block = self.make_one(runtime=runtime)
-
-        response = block.scorm_get_value(
-            mock.Mock(method="POST", body=json.dumps(request_data))
-        )
-        self.assertEqual(response.json, {"value": value})
-
-    @data(
-        ({"name": "cmi.learner_id"}, "edx-platform.user_id", 23),
-        ({"name": "cmi.learner_name"}, "edx-platform.username", "supername"),
-    )
-    @unpack
-    def test_scorm_2004_get_student_data(self, request_data, key, value):
-        service_user_mock = mock.Mock()
-        current_user_mock = mock.Mock()
-        current_user_mock.opt_attrs = {key: value}
-        service_user_mock.configure_mock(
-            **{"get_current_user.return_value": current_user_mock}
-        )
-
-        runtime = mock.Mock()
-        runtime.service.return_value = service_user_mock
-
-        block = self.make_one(runtime=runtime)
-
-        response = block.scorm_get_value(
-            mock.Mock(method="POST", body=json.dumps(request_data))
-        )
-        self.assertEqual(response.json, {"value": value})

--- a/openedxscorm/tests.py
+++ b/openedxscorm/tests.py
@@ -255,3 +255,14 @@ class ScormXBlockTests(unittest.TestCase):
 
         self.assertEqual(response.json, {"value": 20})
 
+    def test_scorm_data_has_user_info_in_student_view(self):
+        block = self.make_one()
+
+        block.student_view()
+        student_info_keys = [
+            "cmi.core.student_id",
+            "cmi.learner_id",
+            "cmi.learner_name",
+            "cmi.core.student_name",
+        ]
+        self.assertTrue(key in block.scorm_data for key in student_info_keys)


### PR DESCRIPTION
After this [change](https://github.com/edly-io/openedx-scorm-xblock/commit/8fe1614648e453f47ab22da92438dda890448fc6), `scorm_get_values` was exclusively used for getting `uncached_values`.

This commit: 
- removes student information and other scorm data from get value func and sends it as part of scorm_data in student view,
- adds `cmi.score.scaled` to `uncached_values`,
- and removes old test cases.