### PR TITLE
fix: S3 storage exists always return false for directories

### DIFF
--- a/changelog.d/20240621_201400_zia.fazal_fix_backward_compat.md
+++ b/changelog.d/20240621_201400_zia.fazal_fix_backward_compat.md
@@ -1,0 +1,1 @@
+- [Bugfix] Make addition of block usage key in scorm path backward compatible. (by @ziafazal)


### PR DESCRIPTION
These changes pass complete path of the index file because  storage.exists expects a file path when storage is set to S3. This should fix issue #76 