### PR TITLE
fix: Scorm iframe and API loading race condition

### DIFF
--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -203,8 +203,10 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
         return self.student_view(context=context)
 
     def student_view(self, context=None):
+        index_page_url = urllib.parse.unquote(self.index_page_url)
+
         student_context = {
-            "index_page_url": urllib.parse.unquote(self.index_page_url),
+            "index_page_url": index_page_url,
             "completion_status": self.lesson_status,
             "grade": self.get_grade(),
             "can_view_student_reports": self.can_view_student_reports,
@@ -228,6 +230,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
                 "popup_width": self.width or 800,
                 "popup_height": self.height or 800,
                 "scorm_data": self.scorm_data,
+                "index_page_url": index_page_url,
             },
         )
         return frag

--- a/openedxscorm/static/html/scormxblock.html
+++ b/openedxscorm/static/html/scormxblock.html
@@ -35,7 +35,6 @@
             </div>
             <iframe
             class="scorm-embedded"
-            src="{{ index_page_url }}"
             width="100%"
             height="100%"
             >

--- a/openedxscorm/static/js/src/scormxblock.js
+++ b/openedxscorm/static/js/src/scormxblock.js
@@ -264,8 +264,16 @@ function ScormXBlock(runtime, element, settings) {
         });
     };
 
+    function initScormIframe() {
+        var iframe = $(element).find('.scorm-embedded');
+        if (iframe.length) {
+            iframe.attr('src', settings.index_page_url);
+        }
+    }
+
     $(function ($) {
         initScorm(settings.scorm_version, GetValue, SetValue);
+        initScormIframe();
         initFullscreen();
         initPopupWindow();
         initReports();


### PR DESCRIPTION
### Description
Load the Scorm iframe's 'src' attribute after initializing the Scorm API instead of directly in the 'scormxblock.html' file because it can lead to a race condition where the Scorm content may load faster and try to access the Scorm API before it is loaded, thus giving an error.