### PR TITLE
feat: Add option to turn on or off fullscreen button in SCORM content

### DIFF
--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -164,6 +164,12 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
         default=False,
         scope=Scope.settings,
     )
+    enable_fullscreen_button = Boolean(
+        display_name=_("Show Fullscreen Button"),
+        help=_("Select True to show fullscreen button in the SCORM content"),
+        default=False,
+        scope=Scope.settings,
+    )
 
     navigation_menu = String(scope=Scope.settings, default="")
 
@@ -278,6 +284,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
             "field_height": self.fields["height"],
             "field_popup_on_launch": self.fields["popup_on_launch"],
             "field_enable_navigation_menu": self.fields["enable_navigation_menu"],
+            "field_fullscreen_button": self.fields["enable_fullscreen_button"],
             "field_navigation_menu_width": self.fields["navigation_menu_width"],
             "popup_on_launch": self.fields["popup_on_launch"],
             "scorm_xblock": self,
@@ -303,6 +310,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
         self.height = parse_int(request.params["height"], None)
         self.has_score = request.params["has_score"] == "1"
         self.enable_navigation_menu = request.params["enable_navigation_menu"] == "1"
+        self.enable_fullscreen_button = request.params["enable_fullscreen_button"] == "1"
         self.navigation_menu_width = parse_int(
             request.params["navigation_menu_width"], None
         )
@@ -344,6 +352,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
                 "navigation_menu": self.navigation_menu,
                 "navigation_menu_width": self.navigation_menu_width,
                 "enable_navigation_menu": self.enable_navigation_menu,
+                "enable_fullscreen_button": self.enable_fullscreen_button,
             },
         )
         return Response(body=rendered)

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -284,7 +284,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
             "field_height": self.fields["height"],
             "field_popup_on_launch": self.fields["popup_on_launch"],
             "field_enable_navigation_menu": self.fields["enable_navigation_menu"],
-            "field_fullscreen_button": self.fields["enable_fullscreen_button"],
+            "field_enable_fullscreen_button": self.fields["enable_fullscreen_button"],
             "field_navigation_menu_width": self.fields["navigation_menu_width"],
             "popup_on_launch": self.fields["popup_on_launch"],
             "scorm_xblock": self,

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -167,7 +167,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
     enable_fullscreen_button = Boolean(
         display_name=_("Show Fullscreen Button"),
         help=_("Select True to show fullscreen button in the SCORM content"),
-        default=False,
+        default=True,
         scope=Scope.settings,
     )
 

--- a/openedxscorm/static/html/scormxblock.html
+++ b/openedxscorm/static/html/scormxblock.html
@@ -9,12 +9,13 @@
   {% endif %}
 
   <div class="scorm-content">
-
+            {% if scorm_xblock.enable_fullscreen_button %}
             <div class="fullscreen-controls">
                 <button class="enter-fullscreen">{% trans "Fullscreen" %}</button>
                 <button class="exit-fullscreen">{% trans "Exit fullscreen" %}</button>
             </div>
-            
+            {% endif %}
+
             <div class="scorm-panel">
 
                 {% if scorm_xblock.enable_navigation_menu and not scorm_xblock.popup_on_launch%}

--- a/openedxscorm/static/html/studio.html
+++ b/openedxscorm/static/html/studio.html
@@ -45,6 +45,17 @@
 
         <li class="field comp-setting-entry is-set">
             <div class="wrapper-comp-setting">
+                <label class="label setting-label" for="enable_fullscreen_button">{% trans field_fullscreen_button.display_name %}</label>
+                <select name="enable_fullscreen_button" id="enable_fullscreen_button">
+                    <option value="1" {% if scorm_xblock.enable_fullscreen_button %}selected{% endif %}>{% trans "True" %}</option>
+                    <option value="0" {% if not scorm_xblock.enable_fullscreen_button %}selected{% endif %}>{% trans "False" %}</option>
+                </select>
+            </div>
+            <span class="tip setting-help">{% trans field_fullscreen_button.help %}</span>
+        </li>
+
+        <li class="field comp-setting-entry is-set">
+            <div class="wrapper-comp-setting">
                 <label class="label setting-label" for="weight">{% trans field_weight.display_name %}</label>
                 <input class="input setting-input" name="weight" id="weight" value="{{ scorm_xblock.weight|unlocalize }}" type="number" />
             </div>

--- a/openedxscorm/static/html/studio.html
+++ b/openedxscorm/static/html/studio.html
@@ -45,13 +45,13 @@
 
         <li class="field comp-setting-entry is-set">
             <div class="wrapper-comp-setting">
-                <label class="label setting-label" for="enable_fullscreen_button">{% trans field_fullscreen_button.display_name %}</label>
+                <label class="label setting-label" for="enable_fullscreen_button">{% trans field_enable_fullscreen_button.display_name %}</label>
                 <select name="enable_fullscreen_button" id="enable_fullscreen_button">
                     <option value="1" {% if scorm_xblock.enable_fullscreen_button %}selected{% endif %}>{% trans "True" %}</option>
                     <option value="0" {% if not scorm_xblock.enable_fullscreen_button %}selected{% endif %}>{% trans "False" %}</option>
                 </select>
             </div>
-            <span class="tip setting-help">{% trans field_fullscreen_button.help %}</span>
+            <span class="tip setting-help">{% trans field_enable_fullscreen_button.help %}</span>
         </li>
 
         <li class="field comp-setting-entry is-set">

--- a/openedxscorm/static/js/src/studio.js
+++ b/openedxscorm/static/js/src/studio.js
@@ -8,6 +8,7 @@ function ScormStudioXBlock(runtime, element) {
         var display_name = $(element).find('input[name=display_name]').val();
         var has_score = $(element).find('select[name=has_score]').val();
         var enable_navigation_menu = $(element).find('select[name=enable_navigation_menu]').val();
+        var enable_fullscreen_button = $(element).find('select[name=enable_fullscreen_button]').val();
         var weight = $(element).find('input[name=weight]').val();
         var width = $(element).find('input[name=width]').val();
         var height = $(element).find('input[name=height]').val();
@@ -18,6 +19,7 @@ function ScormStudioXBlock(runtime, element) {
         form_data.append('display_name', display_name);
         form_data.append('has_score', has_score);
         form_data.append('enable_navigation_menu', enable_navigation_menu);
+        form_data.append('enable_fullscreen_button', enable_fullscreen_button);
         form_data.append('weight', weight);
         form_data.append('width', width);
         form_data.append('height', height);


### PR DESCRIPTION
Some components by default has its own button for full screen functionality. So, the full screen button could be optional where instructors would be able to turn that on or off.