### PR TITLE
ci: upgrade publish_pypi to ubuntu-latest and python 3.12

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -8,15 +8,19 @@ on:
 jobs:
 
    push:
-     runs-on: ubuntu-20.04
+     runs-on: ubuntu-latest
+     environment:
+      name: pypi
+      url: https://pypi.org/project/openedx-scorm-xblock
 
      steps:
        - name: Checkout
-         uses: actions/checkout@v1
+         uses: actions/checkout@v4
+
        - name: setup python
-         uses: actions/setup-python@v2
+         uses: actions/setup-python@v5
          with:
-           python-version: 3.8
+           python-version: 3.12
 
        - name: Install setup tool and wheel
          run: pip install setuptools wheel
@@ -25,7 +29,4 @@ jobs:
          run: python setup.py sdist bdist_wheel
 
        - name: Publish to PyPi
-         uses: pypa/gh-action-pypi-publish@master
-         with:
-           user: __token__
-           password: ${{ secrets.PYPI_UPLOAD_TOKEN }}
+         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
closes #82

** Changes **

- Upgraded ubuntu-20.04 to ubuntu-latest.
- Upgraded from python 3.8 to python 3.12.
- Upgrade checkout and setup-python versions.
- Remove tokens as repository is now already added as a trusted publisher on pypi.