### PR TITLE
docs: Correct docstring for assets_proxy

### DIFF
--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -1,4 +1,4 @@
-import json
+# import json
 import hashlib
 import os
 import logging
@@ -243,8 +243,8 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
     @XBlock.handler
     def assets_proxy(self, request, suffix):
         """
-        Proxy view for serving assets. It receives a request with the path to the asset to serve, generates a pre-signed
-        URL to access the content in the AWS S3 bucket, and returns a redirect response to the pre-signed URL.
+        Proxy view for serving assets. It receives a request with the path to the asset to serve
+        and returns the asset's file contents.
 
         Parameters:
         ----------

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -1,4 +1,4 @@
-# import json
+import json
 import hashlib
 import os
 import logging


### PR DESCRIPTION
I believe this was originally written to serve redirects in https://github.com/overhangio/openedx-scorm-xblock/pull/29 but before merge it was changed to proxy the contents.