### PR TITLE
fix: 'openedxscorm.scormxblock' is not a package

### DIFF
--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -200,7 +200,10 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
     @staticmethod
     def resource_string(path):
         """Handy helper for getting static resources from our kit."""
-        data = importlib_resources.files(__name__).joinpath(path).read_bytes()
+        try:
+            data = importlib_resources.files(__name__).joinpath(path).read_bytes()
+        except TypeError:
+            data = importlib_resources.files(__package__).joinpath(path).read_bytes()
         return data.decode("utf8")
 
     def author_view(self, context=None):


### PR DESCRIPTION
Scorm Xblock was failing in nightly due to importlib_resources being removed. This has been done for backwards compatibility.

Reference PR: https://github.com/edly-io/h5pxblock/pull/42