### PR TITLE
fix: fullscreen page height

### DIFF
--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -242,6 +242,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
                 "popup_width": self.width or 800,
                 "popup_height": self.height or 800,
                 "scorm_data": self.scorm_data,
+                "block_height": self.height or 450,
             },
         )
         return frag

--- a/openedxscorm/static/js/src/scormxblock.js
+++ b/openedxscorm/static/js/src/scormxblock.js
@@ -54,12 +54,16 @@ function ScormXBlock(runtime, element, settings) {
     function onFullscreenChange(e) {
         if (isFullscreen()) {
             $(e.target).addClass("fullscreen-enabled");
+            if (settings.block_height > screen.height) {
+                $(e.target).css("height", screen.height);
+            }
         } else {
             $(e.target).removeClass("fullscreen-enabled");
+            $(e.target).css("height", settings.block_height);
         }
         // This is required to trigger the actual content resize in some packages
         window.dispatchEvent(new Event('resize'));
-    }
+}
 
     // Popup window
     function initPopupWindow() {


### PR DESCRIPTION
> Full screen navigation is very hard to navigate and makes it impossible for users to scroll down completely and access the content. It completely hides the buttons making it impossible to move forward. They have to exit full screen to continue to navigate.
>
> Happens only on certain devices (like a laptop), does not happen as often at higher resolutions.

The solution would be to have the height of `<div class="scorm-pane " />` updated to the screen height if it is less than the saved height.

This PR resolved #92 