### PR TITLE
fix: revert from success callback in GetValue

### DIFF
--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -484,8 +484,10 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
         return os.path.join(self.scorm_location(), self.location.block_id)
 
     def get_mode(self, data):
-        if "preview" in data["url"]:
-            return "review"
+        # TODO: Replace studio with authoring once the pages have been 
+        # fully transferred to the authoring MFE
+        if "preview" in data["url"] or "studio" in data["url"]:
+            return "browse"
         return "normal"
 
     @XBlock.json_handler

--- a/openedxscorm/static/js/src/scormxblock.js
+++ b/openedxscorm/static/js/src/scormxblock.js
@@ -190,20 +190,18 @@ function ScormXBlock(runtime, element, settings) {
         // Only make a call if navigation menu was not used
         // Otherwise the synchronous calls are blocked by chromium on page unload
         if (uncachedValues.includes(cmi_element) && !navigationClick){
-            $.ajax({
+            // Force synchronous code here as SCORM expects it
+            var response = $.ajax({
                 type: "POST",
                 url: getValueUrl,
                 data: JSON.stringify({
                     'name': cmi_element,
                     'url': window.location.href
                 }),
-                async: false,
-                success: function (response) {
-                    // Set to false to allow for other calls by the SCORM api
-                    navigationClick = false;
-                    return response.value;
-                }
-            });
+                async: false
+            })
+            response = JSON.parse(response.responseText);
+            return response.value;
         } else if (cmi_element in settings.scorm_data) {
             navigationClick = false;
             return settings.scorm_data[cmi_element];


### PR DESCRIPTION
closes #43

`async: false` has been [deprecated](https://api.jquery.com/jQuery.ajax/) as of jquery 1.8 and it is no longer working in scorms case with the success handler. Therefore, we revert back to the code where we receive the response and then move on with the code.
