### PR TITLE
fix: make scorm panel cover entire height in fullscreen mode

### DIFF
--- a/changelog.d/20250203_142818_danyal.faheem_HEAD.md
+++ b/changelog.d/20250203_142818_danyal.faheem_HEAD.md
@@ -1,0 +1,1 @@
+- [Bugfix] Make scorm panel and navigation menu cover the entire height of the display in fullscreen. (by @Danyal-Faheem)

--- a/openedxscorm/static/js/src/scormxblock.js
+++ b/openedxscorm/static/js/src/scormxblock.js
@@ -57,9 +57,15 @@ function ScormXBlock(runtime, element, settings) {
             if (settings.block_height > screen.height) {
                 $(e.target).css("height", screen.height);
             }
+            // Override height and cover entire display in fullscreen
+            $(e.target).find(".scorm-panel").css("height", "100%");
+            $(e.target).find(".scorm-pane").css("height", "100%");
         } else {
             $(e.target).removeClass("fullscreen-enabled");
-            $(e.target).css("height", settings.block_height);
+            // Revert back to custom height on fullscreen exit
+            $(e.target).removeAttr("style");
+            $(e.target).find(".scorm-panel").removeAttr("style");
+            $(e.target).find(".scorm-pane").css("height", settings.block_height);
         }
         // This is required to trigger the actual content resize in some packages
         window.dispatchEvent(new Event('resize'));


### PR DESCRIPTION
fixes #96.

The scorm panel would retain any custom height set or the default 450px height in fullscreen mode thus defeating the purpose of the fullscreen mode.

We now cover the entire display in fullscreen mode.