### PR TITLE
perf: provide option to query asset using storage default url or through the LMS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,19 @@ This should be added both to the LMS and the CMS settings. Instead of a function
 
 Note that the SCORM XBlock comes with extended S3 storage support out of the box. See the following section:
 
+Default storage URL
+~~~~~~~~~~~~~~~~~~
+
+By default, scorm will proxy assets through the LMS. This is done for security and to make the backend generic enough to be used with different storage backends. However, to utilize the default storage defined url, add the following to the ScormXBlock settings::
+
+.. code-block:: python
+
+    XBLOCK_SETTINGS["ScormXBlock"] = {
+        "DEFAULT_STORAGE_URL": True,
+    }    
+
+Scorm will now use the configured storages default `url` method instead of proxying the data through the LMS. The url method must be defined on the configured storage class for this work.
+
 S3 storage
 ~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -106,18 +106,18 @@ This should be added both to the LMS and the CMS settings. Instead of a function
 
 Note that the SCORM XBlock comes with extended S3 storage support out of the box. See the following section:
 
-Default storage URL
-~~~~~~~~~~~~~~~~~~
+Accessing assets directly from storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, scorm will proxy assets through the LMS. This is done for security and to make the backend generic enough to be used with different storage backends. However, to utilize the default storage defined url, add the following to the ScormXBlock settings::
+By default, scorm will proxy assets through the LMS. This is done for security and to make the backend generic enough to be used with different storage backends. However, to access assets directly from the default storage backend, add the following to the ScormXBlock settings:
 
 .. code-block:: python
 
     XBLOCK_SETTINGS["ScormXBlock"] = {
-        "DEFAULT_STORAGE_URL": True,
+        "PROXY_ASSETS_LMS": False,
     }    
 
-Scorm will now use the configured storages default `url` method instead of proxying the data through the LMS. The url method must be defined on the configured storage class for this work.
+Scorm will now use the configured storage backends default `url` method instead of proxying the data through the LMS. The url method must be defined on the configured storage class for this to work correctly.
 
 S3 storage
 ~~~~~~~~~~

--- a/changelog.d/20250307_193543_danyal.faheem.md
+++ b/changelog.d/20250307_193543_danyal.faheem.md
@@ -1,1 +1,1 @@
-- [Improvement] Provide an option to use the default storage url to get scorm assets or proxy them through the LMS. (by @Danyal-Faheem)
+- [Improvement] Provide an option to use the default storage backend url to access scorm assets directly from storage. (by @Danyal-Faheem)

--- a/changelog.d/20250307_193543_danyal.faheem.md
+++ b/changelog.d/20250307_193543_danyal.faheem.md
@@ -1,0 +1,1 @@
+- [Improvement] Provide an option to use the default storage url to get scorm assets or proxy them through the LMS. (by @Danyal-Faheem)

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -383,14 +383,20 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
     def index_page_url(self):
         if not self.package_meta or not self.index_page_path:
             return ""
+        
+        if not self.xblock_settings.get("DEFAULT_STORAGE_URL", False):
+            return f"{self.proxy_base_url}/{self.index_page_path}"
+        
+        folder = self.extract_folder_path
         if self.storage.exists(
             os.path.join(self.extract_folder_base_path, self.clean_path(self.index_page_path))
         ):
             # For backward-compatibility, we must handle the case when the xblock data
             # is stored in the base folder.
-            logger.warning("Serving SCORM content from old-style path: %s", self.extract_folder_base_path)
+            folder = self.extract_folder_base_path
+            logger.warning("Serving SCORM content from old-style path: %s", folder)
 
-        return f"{self.proxy_base_url}/{self.index_page_path}"
+        return self.storage.url(os.path.join(folder, self.index_page_path))
 
     @property
     def proxy_base_url(self):

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -384,7 +384,8 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
         if not self.package_meta or not self.index_page_path:
             return ""
         
-        if not self.xblock_settings.get("DEFAULT_STORAGE_URL", False):
+        # Serve assets by proxying them through the LMS by default
+        if self.xblock_settings.get("PROXY_ASSETS_LMS", True):
             return f"{self.proxy_base_url}/{self.index_page_path}"
         
         folder = self.extract_folder_path

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -55,43 +55,6 @@ OS_PATH_ALT_SEP = '\\'
 @XBlock.wants("settings")
 @XBlock.wants("user")
 class ScormXBlock(XBlock, CompletableXBlockMixin):
-    """
-    When a user uploads a Scorm package, the zip file is stored in:
-
-        media/{org}/{course}/{block_type}/{block_id}/{sha1}{ext}
-
-    This zip file is then extracted to the media/{scorm_location}/{block_id}.
-
-    The scorm location is defined by the LOCATION xblock setting. If undefined, this is
-    "scorm". This setting can be set e.g:
-
-        XBLOCK_SETTINGS["ScormXBlock"] = {
-            "LOCATION": "alternatevalue",
-        }
-
-    Note that neither the folder the folder nor the package file are deleted when the
-    xblock is removed.
-
-    By default, static assets are stored in the default Django storage backend. To
-    override this behaviour, you should define a custom storage function. This
-    function must take the xblock instance as its first and only argument. For instance,
-    you can store assets in different directories depending on the XBlock organization with::
-
-        def scorm_storage(xblock):
-            from django.conf import settings
-            from django.core.files.storage import FileSystemStorage
-            from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
-
-            subfolder = SiteConfiguration.get_value_for_org(
-                xblock.location.org, "SCORM_STORAGE_NAME", "default"
-            )
-            storage_location = os.path.join(settings.MEDIA_ROOT, subfolder)
-            return get_storage_class(settings.DEFAULT_FILE_STORAGE)(location=storage_location)
-
-        XBLOCK_SETTINGS["ScormXBlock"] = {
-            "STORAGE_FUNC": scorm_storage,
-        }
-    """
 
     display_name = String(
         display_name=_("Display Name"),


### PR DESCRIPTION
fixes #99.

A change was introduced in #91 where instead of accessing the url method on the storage backend, we would proxy the assets through the LMS. This was done to generalize the backend and allow for it to work out of the box with external storages such as S3.

However, as pointed out in #99, this can lead to some degraded performance as compared to just accessing scorm files directly from an external storage. Hence, we provide an option to change this behaviour and it is up to the user to choose them.

The default option will be proxying through the LMS as it does not require any extra setup. 

An important concept necessary here is that the `url` method must be defined on the storage if the `DEFAULT_STORAGE_URL` option is set to true.