### PR TITLE
fix: set completion_status to completed when lesson_status is passed

### DIFF
--- a/changelog.d/20250808_091751_sorlanczyk_fix_scrom1_2_completion.md
+++ b/changelog.d/20250808_091751_sorlanczyk_fix_scrom1_2_completion.md
@@ -1,0 +1,12 @@
+
+<!--
+Create a changelog entry for every new user-facing change. Please respect the following instructions:
+- Indicate breaking changes by prepending an explosion 💥 character.
+- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
+- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
+of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+the release notes for every release.
+-->
+
+<!-- - 💥[Feature] Foobarize the blorginator. This breaks plugins by renaming the `FOO_DO` filter to `BAR_DO`. (by @regisb) -->
+<!-- - [Improvement] This is a non-breaking change. Life is good. (by @billgates) -->

--- a/changelog.d/20250808_091751_sorlanczyk_fix_scrom1_2_completion.md
+++ b/changelog.d/20250808_091751_sorlanczyk_fix_scrom1_2_completion.md
@@ -1,1 +1,1 @@
-- [Bugfix] fixed logic bug in SCORM 1.2 completion handling, when `lesson_status` is `passed` or `failed` it will ensure course completion status. (by @so-jd)
+- [Bugfix] Set completion_status to completed when lesson_status is passed to ensure course completion status in SCORM 1.2. (by @so-jd)

--- a/changelog.d/20250808_091751_sorlanczyk_fix_scrom1_2_completion.md
+++ b/changelog.d/20250808_091751_sorlanczyk_fix_scrom1_2_completion.md
@@ -1,12 +1,1 @@
-
-<!--
-Create a changelog entry for every new user-facing change. Please respect the following instructions:
-- Indicate breaking changes by prepending an explosion 💥 character.
-- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
-- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
-of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
-the release notes for every release.
--->
-
-<!-- - 💥[Feature] Foobarize the blorginator. This breaks plugins by renaming the `FOO_DO` filter to `BAR_DO`. (by @regisb) -->
-<!-- - [Improvement] This is a non-breaking change. Life is good. (by @billgates) -->
+- [Bugfix] fixed logic bug in SCORM 1.2 completion handling, when `lesson_status` is `passed` or `failed` it will ensure course completion status. (by @so-jd)

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -506,6 +506,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
             lesson_status = value
             if lesson_status in ["passed", "failed"]:
                 success_status = lesson_status
+                completion_status = "completed"
             elif lesson_status in ["completed", "incomplete"]:
                 completion_status = lesson_status
         elif name == "cmi.success_status":

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -506,7 +506,8 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
             lesson_status = value
             if lesson_status in ["passed", "failed"]:
                 success_status = lesson_status
-                completion_status = "completed"
+                if lesson_status == "passed":
+                    completion_status = "completed"
             elif lesson_status in ["completed", "incomplete"]:
                 completion_status = lesson_status
         elif name == "cmi.success_status":


### PR DESCRIPTION
I found a logic bug, relating to this issue https://github.com/overhangio/openedx-scorm-xblock/issues/90 (was experiencing it as well).

In SCORM 2004 you have:
"cmi.completion_status" = "completed" / "incomplete" / "not attempted" / "unknown" - this event Indicates whether the learner has completed the SCO
"cmi.success_status" = "passed" / "failed" - Indicates whether the learner has mastered the SCO

but in SCORM 1.2:
"cmi.core.lesson_status" = “passed”/ “completed”/ “failed”/ “incomplete”/ “browsed”/ “not attempted” - Indicates whether the learner has completed AND satisfied the requirements for the SCO

In the code when evaluating "cmi.core.lesson_status" == passedwe need to also set the complete status otherwise SCROM 1.2 courses will not end successfully

ref: https://scorm.com/scorm-explained/technical-scorm/run-time/run-time-reference/#section-3