### PR TITLE
fix: hide navigation menu and scorm content width

### DIFF
--- a/changelog.d/20251020_132353_faraz.maqsood.md
+++ b/changelog.d/20251020_132353_faraz.maqsood.md
@@ -1,0 +1,1 @@
+- [Bugfix] Don't show navigation menu and change scorm content width from 70% to 100% when navigation menu is disabled in new pop-up window. (by @Faraz32123)

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -319,6 +319,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
                 "navigation_menu_width": self.navigation_menu_width,
                 "enable_navigation_menu": self.enable_navigation_menu,
                 "enable_fullscreen_button": self.enable_fullscreen_button,
+                "popup_on_launch": self.popup_on_launch,
             },
         )
         return Response(body=rendered)

--- a/openedxscorm/static/html/popup.html
+++ b/openedxscorm/static/html/popup.html
@@ -42,18 +42,23 @@
                     width: 70%;
                     height: 700px;
                 }
+                .navigation-disabled {
+                    width: 100%;
+                }
             }
         </style>
     </head>
     <body>
         <div class="scorm-xblock">
-            <div class="navigational-panel" style="width: {% if scorm_xblock.navigation_menu_width %}{{scorm_xblock.navigation_menu_width}}px{% else %}30%{% endif %};">
+            {% if enable_navigation_menu and popup_on_launch %}
+            <div class="navigational-panel" style="width: {% if navigation_menu_width %}{{navigation_menu_width}}px{% else %}30%{% endif %};">
                 <h4>Table of contents</h4>
                 <ul>
                     {{navigation_menu|safe }}
                 </ul>
             </div>
-        <iframe class="scorm-embedded" src="{{ index_page_url }}" width="{{ width }}" height="{{ height }}"></iframe>
+            {% endif %}
+        <iframe class="scorm-embedded {% if not enable_navigation_menu %}navigation-disabled{% endif %}" src="{{ index_page_url }}" width="{{ width }}" height="{{ height }}"></iframe>
         <script>
             window.resizeTo({{ width }} + 20, {{ height }} + 20);
             window.onload = function () {


### PR DESCRIPTION
- Don't show navigation menu and change scorm content width from 70% to 100% when navigation menu is disabled in new pop-up window.

**Before:**
<video src="https://github.com/user-attachments/assets/75ca71da-8358-49cb-b862-c0c92e21f91b" controls></video>

**After:**
<video src="https://github.com/user-attachments/assets/78d6e4bc-c13a-4d5a-8be3-7e7c8b43e26b" controls></video>
