### PR TITLE
fix: resolve scorm assets at the exact requested path

### DIFF
--- a/changelog.d/20260504184023_djoseph_assets_proxy_paths.md
+++ b/changelog.d/20260504184023_djoseph_assets_proxy_paths.md
@@ -1,0 +1,1 @@
+- [Bugfix] Serve SCORM assets at the exact requested path, fixing blank-page rendering for packages containing duplicate basenames such as Articulate Rise packages with multiple `scormdriver.js` files. Also reject path traversal and absolute paths in asset URLs. (by @djoseph)

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -234,7 +234,7 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
         try:
             clean_suffix = self.clean_asset_path(suffix)
         except ScormError:
-            logger.warning("Invalid asset path: %r", suffix)
+            logger.error("Invalid asset path: %r", suffix)
             return Response("Invalid asset path", status=400, content_type="text/plain")
         file_name = os.path.basename(clean_suffix)
         requested_path = os.path.join(self.extract_folder_path, clean_suffix)
@@ -635,20 +635,27 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
     def clean_asset_path(self, path):
         """
         Clean and validate an asset path requested through the proxy.
+        Asset paths must be relative paths that stay within the extracted
+        package folder. Absolute paths, drive-letter paths, parent-directory
+        traversal, and null bytes are rejected.
         """
         cleaned = urllib.parse.unquote(self.clean_path(path))
-        if not cleaned or "\x00" in cleaned or cleaned.endswith(("/", OS_PATH_ALT_SEP)):
-            raise ScormError("Invalid asset path")
+        if not cleaned:
+            raise ScormError(f"Invalid asset path (empty): {path!r}")
+        if "\x00" in cleaned:
+            raise ScormError(f"Invalid asset path (null byte): {path!r}")
+        if cleaned.endswith(("/", OS_PATH_ALT_SEP)):
+            raise ScormError(f"Invalid asset path (directory, not a file): {path!r}")
+
         normalized_separators_path = cleaned.replace(OS_PATH_ALT_SEP, os.path.sep)
         path_parts = normalized_separators_path.split(os.path.sep)
         cleaned = os.path.normpath(normalized_separators_path)
-        if (
-            os.path.isabs(cleaned)
-            or cleaned == os.curdir
-            or re.match(r"^[A-Za-z]:", cleaned)
-            or os.pardir in path_parts
-        ):
-            raise ScormError("Invalid asset path")
+
+        if os.path.isabs(cleaned) or re.match(r"^[A-Za-z]:", cleaned):
+            raise ScormError(f"Invalid asset path (must be relative): {path!r}")
+        if cleaned == os.curdir or os.pardir in path_parts:
+            raise ScormError(f"Invalid asset path (path traversal): {path!r}")
+
         return cleaned
     
     def path_exists(self, path):

--- a/openedxscorm/scormxblock.py
+++ b/openedxscorm/scormxblock.py
@@ -231,8 +231,20 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
         -------
         Response object containing the content of the requested file with the appropriate content type.
         """
-        file_name = os.path.basename(suffix)
-        file_path = self.find_file_path(file_name)
+        try:
+            clean_suffix = self.clean_asset_path(suffix)
+        except ScormError:
+            logger.warning("Invalid asset path: %r", suffix)
+            return Response("Invalid asset path", status=400, content_type="text/plain")
+        file_name = os.path.basename(clean_suffix)
+        requested_path = os.path.join(self.extract_folder_path, clean_suffix)
+        if self.storage.exists(requested_path):
+            file_path = requested_path
+        else:
+            # Preserve legacy basename lookup for packages or callers that do
+            # not request the extracted relative path. Exact-path lookup above
+            # avoids this fallback for normal requests with duplicate basenames.
+            file_path = self.find_file_path(file_name)
         file_type, _ = mimetypes.guess_type(file_name)
         with self.storage.open(file_path) as response:
             file_content = response.read()
@@ -619,6 +631,25 @@ class ScormXBlock(XBlock, CompletableXBlockMixin):
         Removes query string from a path
         """
         return path.split('?')[0] if path else path
+
+    def clean_asset_path(self, path):
+        """
+        Clean and validate an asset path requested through the proxy.
+        """
+        cleaned = urllib.parse.unquote(self.clean_path(path))
+        if not cleaned or "\x00" in cleaned or cleaned.endswith(("/", OS_PATH_ALT_SEP)):
+            raise ScormError("Invalid asset path")
+        normalized_separators_path = cleaned.replace(OS_PATH_ALT_SEP, os.path.sep)
+        path_parts = normalized_separators_path.split(os.path.sep)
+        cleaned = os.path.normpath(normalized_separators_path)
+        if (
+            os.path.isabs(cleaned)
+            or cleaned == os.curdir
+            or re.match(r"^[A-Za-z]:", cleaned)
+            or os.pardir in path_parts
+        ):
+            raise ScormError("Invalid asset path")
+        return cleaned
     
     def path_exists(self, path):
         """

--- a/openedxscorm/tests.py
+++ b/openedxscorm/tests.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 import mock
 from xblock.field_data import DictFieldData
 
-from .scormxblock import ScormXBlock
+from .scormxblock import ScormError, ScormXBlock
 
 
 @ddt
@@ -24,6 +24,14 @@ class ScormXBlockTests(unittest.TestCase):
             block_id="block_id", org="org", course="course", block_type="block_type"
         )
         return block
+
+    @staticmethod
+    def make_storage_with_file(content=b"content"):
+        storage = mock.Mock()
+        opened_file = mock.MagicMock()
+        opened_file.__enter__.return_value.read.return_value = content
+        storage.open.return_value = opened_file
+        return storage
 
     def test_fields_xblock(self):
         block = self.make_one()
@@ -123,6 +131,94 @@ class ScormXBlockTests(unittest.TestCase):
         file_storage_path = block.package_path
 
         self.assertEqual(file_storage_path, "org/course/block_type/block_id/sha1.html")
+
+    @mock.patch.object(
+        ScormXBlock, "extract_folder_path", new_callable=mock.PropertyMock
+    )
+    def test_assets_proxy_serves_exact_requested_path(self, extract_folder_path):
+        block = self.make_one()
+        storage = self.make_storage_with_file(b"exact asset")
+        storage.exists.return_value = True
+        block._storage = storage
+        block.find_file_path = mock.Mock(return_value="scorm/block/sha1/other/app.js")
+        extract_folder_path.return_value = "scorm/block/sha1"
+
+        response = block.assets_proxy(mock.Mock(), "assets/app.js")
+
+        storage.exists.assert_called_once_with("scorm/block/sha1/assets/app.js")
+        block.find_file_path.assert_not_called()
+        storage.open.assert_called_once_with("scorm/block/sha1/assets/app.js")
+        self.assertEqual(response.body, b"exact asset")
+
+    @mock.patch.object(
+        ScormXBlock, "extract_folder_path", new_callable=mock.PropertyMock
+    )
+    def test_assets_proxy_fallback_uses_cleaned_basename(self, extract_folder_path):
+        block = self.make_one()
+        storage = self.make_storage_with_file()
+        storage.exists.return_value = False
+        block._storage = storage
+        block.find_file_path = mock.Mock(return_value="scorm/block/sha1/fallback/app.js")
+        extract_folder_path.return_value = "scorm/block/sha1"
+
+        block.assets_proxy(mock.Mock(), "assets/app.js?v=1")
+
+        storage.exists.assert_called_once_with("scorm/block/sha1/assets/app.js")
+        block.find_file_path.assert_called_once_with("app.js")
+        storage.open.assert_called_once_with("scorm/block/sha1/fallback/app.js")
+
+    @data(
+        "",
+        "?v=1",
+        ".",
+        "/app.js",
+        "%2Fapp.js",
+        "%5Capp.js",
+        r"C:\app.js",
+        "C%3A/app.js",
+        "../app.js",
+        "%2E%2E/app.js",
+        "assets/",
+        "assets/..",
+        "assets/%2E%2E/app.js",
+        "assets/../../app.js",
+        "assets/%2E%2E/%2E%2E/app.js",
+        r"assets\..\app.js",
+        "assets/%00/app.js",
+    )
+    def test_assets_proxy_rejects_invalid_requested_paths(self, suffix):
+        block = self.make_one()
+
+        response = block.assets_proxy(mock.Mock(), suffix)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(response.body, b"Invalid asset path")
+
+    @data(
+        "",
+        "?v=1",
+        ".",
+        "/app.js",
+        "%2Fapp.js",
+        "%5Capp.js",
+        r"C:\app.js",
+        "C%3A/app.js",
+        "../app.js",
+        "%2E%2E/app.js",
+        "assets/",
+        "assets/..",
+        "assets/%2E%2E/app.js",
+        "assets/../../app.js",
+        "assets/%2E%2E/%2E%2E/app.js",
+        r"assets\..\app.js",
+        "assets/%00/app.js",
+    )
+    def test_clean_asset_path_rejects_invalid_requested_paths(self, suffix):
+        block = self.make_one()
+
+        with self.assertRaises(ScormError):
+            block.clean_asset_path(suffix)
 
     @mock.patch(
         "openedxscorm.ScormXBlock._file_storage_path", return_value="file_storage_path"


### PR DESCRIPTION
## Overview

**Fix SCORM asset proxy resolution so asset requests prefer the exact requested path instead of resolving by basename only.**

Previously, `assets_proxy` discarded the directory portion of the requested URL and recursively searched for the first file with the same basename. Packages containing duplicate filenames at different paths could therefore serve the wrong asset, causing runtime failures such as blank-page rendering in Articulate Rise exports with multiple `scormdriver.js` files.

 ##  Reported issue

[Issue No:112](https://github.com/overhangio/openedx-scorm-xblock/issues/112)

  ## Details

  - Try the exact extracted asset path first.
  - Preserve the legacy basename fallback for compatibility when the exact path is not found.
  - Add validation for invalid asset paths:
    - empty paths
    - directory-only paths
    - path traversal via `..`
    - URL-encoded traversal such as `%2E%2E`
    - absolute paths
    - Windows drive-style paths
    - null bytes
  - Return `400 Bad Request` for invalid asset URLs instead of surfacing an unhandled exception.
  - Avoid reflecting rejected path input in the response body.
  - Add focused tests for exact-path resolution, fallback behavior, and invalid path rejection.

  ## Notes

 The basename fallback is intentionally preserved for backward compatibility, but exact-path lookup now handles normal requests first to avoid duplicate-basename collisions.

  Invalid asset URLs now return `400 Bad Request`. The pre-existing `ScormError` behavior for missing files found via `find_file_path` is unchanged in this PR.

## Testing

  ```bash
python -m pytest openedxscorm/tests.py -k 'assets_proxy or clean_asset_path'
```

  Result:

  36 passed, 19 deselected